### PR TITLE
Fix PyPI trusted publishing and bump Actions to Node.js 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           # cache: 'pip'
@@ -118,18 +118,16 @@ jobs:
           git push origin v${{ steps.versioning.outputs.newVersion }}
 
       - name: Create GitHub Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.versioning.outputs.newVersion }}
-          name: v${{ steps.versioning.outputs.newVersion }}
-          draft: false
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: true
+        run: |
+          gh release create \
+            "v${{ steps.versioning.outputs.newVersion }}" \
+            --title "v${{ steps.versioning.outputs.newVersion }}" \
+            --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout the merged development branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }} # This is the branch that was merged into main
           fetch-depth: 0 # Fetch all history for all branches and tags
@@ -143,40 +141,3 @@ jobs:
           git merge origin/main --no-edit -X ours
           # If conflicts arise and are resolved, or if no conflicts occur, proceed to push
           git push origin HEAD:${{ github.head_ref }}
-
-      - name: Build release distributions
-        run: |
-          python -m pip install build
-          python -m build
-
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    
-    needs:
-      - build-new-version
-    
-    runs-on: ubuntu-latest
-    
-    environment:
-      name: pypi
-      url: https://pypi.org/p/office-templates
-    
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-    
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to PyPI
+
+on:
+  workflow_run:
+    workflows: ["Release New Version"]
+    types: [completed]
+
+jobs:
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/office-templates
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Checkout latest version tag
+        run: git checkout $(git describe --tags --abbrev=0)
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "office-templates"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "python-pptx" },


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v6 and `actions/setup-python` from v5 to v6 for Node.js 24 compatibility
- Replace `softprops/action-gh-release@v2` with a native `gh release create` shell command
- Extract PyPI publishing into a separate `publish.yml` workflow triggered by the release workflow, enabling proper trusted publishing with OIDC

## Test plan
- [ ] Verify the release workflow (`build.yml`) runs successfully on a merged PR
- [ ] Verify the publish workflow (`publish.yml`) triggers after a successful release and publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)