### PR TITLE
release: create-merge-pr skill — stop folding branch delete into merge

### DIFF
--- a/.agents/skills/create-merge-pr/SKILL.md
+++ b/.agents/skills/create-merge-pr/SKILL.md
@@ -22,10 +22,17 @@ by where you are:
 2. **Do not bump the version** — bumps happen only on releases (Pathway B).
 
 3. Merge with a merge commit — **do not squash** (it loses the individual
-   commits):
+   commits), and **do NOT pass `--delete-branch`** (the branch is deleted
+   separately, in step 4):
 
    ```
-   gh pr merge --merge --delete-branch
+   gh pr merge --merge
+   ```
+
+4. Delete the branch, directly after the merge:
+
+   ```
+   git push origin --delete <branch>
    ```
 
 ## Pathway B (release pathway) — `develop` → `main`
@@ -61,6 +68,8 @@ A `develop` → `main` PR is a release — merging it triggers publishing to PyP
    ```
    gh pr merge --merge
    ```
+
+4. **Do not delete the branch.**
 
 ## Checks (both pathways)
 

--- a/.agents/skills/create-merge-pr/SKILL.md
+++ b/.agents/skills/create-merge-pr/SKILL.md
@@ -5,40 +5,64 @@ description: Create a pull request, bump the version, and merge. Use whenever yo
 
 # create-merge-pr
 
-The standard way to land a change in this repo.
+The standard way to land a change in this repo. There are two pathways — pick
+by where you are:
 
-## 1. Open the PR
+- **On a feature branch** → Pathway A (feature pathway): land it into `develop`.
+- **Already on `develop`** → Pathway B (release pathway): release `develop` into `main`.
 
-Push your branch and open a PR. **Target `develop` by default.** Only target
-`main` if the task explicitly says to release — a `develop` → `main` PR is a
-release and triggers publishing to PyPI.
+## Pathway A (feature pathway) — feature branch → `develop`
 
-```
-gh pr create --base develop --title "<title>" --body "<body>"
-```
+1. Push your branch and open a PR targeting `develop`:
 
-## 2. Bump the version — easy to forget, so don't
+   ```
+   gh pr create --base develop --title "<title>" --body "<body>"
+   ```
 
-The version is **not** bumped automatically. If you skip this, your change lands
-but no release is ever cut. When your change should ship, bump it — run the
-**Bump Version** workflow, which commits the bump to `develop`:
+2. **Do not bump the version** — bumps happen only on releases (Pathway B).
 
-```
-gh workflow run "Bump Version" --ref develop -f bump_type=patch
-```
+3. Merge with a merge commit — **do not squash** (it loses the individual
+   commits):
 
-`patch` by default; `minor` for new features, `major` for breaking changes.
+   ```
+   gh pr merge --merge --delete-branch
+   ```
 
-(The bump commits directly to `develop`, independent of your PR — you don't need
-it in your branch.)
+## Pathway B (release pathway) — `develop` → `main`
 
-## 3. Merge
+A `develop` → `main` PR is a release — merging it triggers publishing to PyPI.
 
-Use a merge commit — **do not squash**:
+1. Open the PR from `develop` into `main`:
 
-```
-gh pr merge --merge --delete-branch
-```
+   ```
+   gh pr create --base main --head develop --title "<title>" --body "<body>"
+   ```
+
+2. **Bump the version — easy to forget, so don't.** The version is **not**
+   bumped automatically; if you skip this, no release is cut. Run the
+   **Bump Version** workflow, which commits the bump to `develop`:
+
+   ```
+   gh workflow run "Bump Version" --ref develop -f bump_type=patch
+   ```
+
+   `patch` by default; `minor` for new features, `major` for breaking changes.
+
+   The workflow commits directly to the **remote** `develop`, so your local
+   `develop` is now stale. Wait for the workflow to finish, then re-pull:
+
+   ```
+   git pull origin develop
+   ```
+
+3. Merge with a merge commit — **do not squash**, and **do NOT pass
+   `--delete-branch`** (it would delete `develop`):
+
+   ```
+   gh pr merge --merge
+   ```
+
+## Checks (both pathways)
 
 Checks (`lint`, `test`) run automatically and must pass — `main` is protected,
 so a red PR cannot be merged. If something's red, fix it and push; you can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "office-templates"
-version = "0.5.4"
+version = "0.5.5"
 description = "Generates Office documents (PPTX/XLSX) from template files that are flexibly populated or composed using provided context."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "office-templates"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "python-pptx" },


### PR DESCRIPTION
Release the `create-merge-pr` skill fix.

`gh pr merge --delete-branch` folded the branch delete into the merge. Branches
here usually have a worktree attached, so gh's cleanup step failed partway
("fatal: 'develop' is already used by worktree") and left the PR merged but the
remote branch alive. The error reads like the whole command failed, when only
the cleanup did.

Pathway A now merges with a plain `gh pr merge --merge` and deletes the branch
as its own step directly after. Pathway B gains an explicit "do not delete the
branch" step.

The merge procedure is now byte-identical across all ten Gaussian repos carrying
this skill. `## Checks` and the release-semantics line stay repo-specific, since
the lint command, the extras flag and the publish target genuinely differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2Wy19NoMr7gom4AUdrLVd
